### PR TITLE
Add new read() method that sets read buffer size

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -16,17 +16,21 @@ public class SerialBuffer
     private byte[] readBufferCompatible; // Read buffer for android < 4.2
     private boolean debugging = false;
 
+    private boolean version;
+    private int readBufferSize = DEFAULT_READ_BUFFER_SIZE;
+
     public SerialBuffer(boolean version)
     {
         writeBuffer = new SynchronizedBuffer();
         if(version)
         {
-            readBuffer = ByteBuffer.allocate(DEFAULT_READ_BUFFER_SIZE);
+            readBuffer = ByteBuffer.allocate(readBufferSize);
 
         }else
         {
-            readBufferCompatible = new byte[DEFAULT_READ_BUFFER_SIZE];
+            readBufferCompatible = new byte[readBufferSize];
         }
+        this.version = version;
     }
 
     /*
@@ -35,6 +39,31 @@ public class SerialBuffer
     public void debug(boolean value)
     {
         debugging = value;
+    }
+
+    public void setReadBufferSize(int readBufferSize)
+    {
+        synchronized (this)
+        {
+            if(version)
+            {
+                readBuffer = ByteBuffer.allocate(readBufferSize);
+
+            }else
+            {
+                readBufferCompatible = new byte[readBufferSize];
+            }
+
+            this.readBufferSize = readBufferSize;
+        }
+    }
+
+    public int getReadBufferSize()
+    {
+        synchronized (this)
+        {
+            return readBufferSize;
+        }
     }
 
     public ByteBuffer getReadBuffer()

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -160,23 +160,30 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
     @Override
     public int read(UsbReadCallback mCallback)
     {
+        return read(mCallback, serialBuffer.getReadBufferSize());
+    }
+
+    @Override
+    public int read(UsbReadCallback callback, int readBufferSize) {
         if(!asyncMode)
             return -1;
+
+        if(readBufferSize != serialBuffer.getReadBufferSize())
+            serialBuffer.setReadBufferSize(readBufferSize);
 
         if(mr1Version)
         {
             if (workerThread != null) {
-                workerThread.setCallback(mCallback);
-                workerThread.getUsbRequest().queue(serialBuffer.getReadBuffer(), SerialBuffer.DEFAULT_READ_BUFFER_SIZE);
+                workerThread.setCallback(callback);
+                workerThread.getUsbRequest().queue(serialBuffer.getReadBuffer(), serialBuffer.getReadBufferSize());
             }
         }else
         {
-            readThread.setCallback(mCallback);
+            readThread.setCallback(callback);
             //readThread.start();
         }
         return 0;
     }
-
 
     @Override
     public abstract void close();
@@ -366,7 +373,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
                     onReceivedData(data);
                 }
                 // Queue a new request
-                requestIN.queue(serialBuffer.getReadBuffer(), SerialBuffer.DEFAULT_READ_BUFFER_SIZE);
+                requestIN.queue(serialBuffer.getReadBuffer(), serialBuffer.getReadBufferSize());
             }
         }
 
@@ -434,7 +441,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             int numberBytes;
             if(inEndpoint != null)
                 numberBytes = connection.bulkTransfer(inEndpoint, serialBuffer.getBufferCompatible(),
-                        SerialBuffer.DEFAULT_READ_BUFFER_SIZE, 0);
+                        serialBuffer.getReadBufferSize(), 0);
             else
                 numberBytes = 0;
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialInterface.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialInterface.java
@@ -32,6 +32,7 @@ public interface UsbSerialInterface
     boolean open();
     void write(byte[] buffer);
     int read(UsbReadCallback mCallback);
+    int read(UsbReadCallback mCallback, int readBufferSize);
     void close();
 
     // Common Usb Serial Operations (I/O Synchronous)


### PR DESCRIPTION
New read(UsbReadCallback, int) method added that takes additional parameter which defines size of the read buffer when communicating asynchronously.